### PR TITLE
fix nss error for inkscape 1.1, 1.2.x on linux

### DIFF
--- a/linux/inkscape-1.0/inkporter.py
+++ b/linux/inkscape-1.0/inkporter.py
@@ -386,7 +386,7 @@ class Inkporter(inkex.Effect):
                 "please install it if you want (optional).")
             self.with_zenity = False
         if len(self.options.id_pattern) > 0:
-            new_nss = inkex.utils.NSS
+            new_nss = inkex.NSS
             new_nss[u're'] = u'http://exslt.org/regular-expressions'
             path_to_compile = "//*[re:match(@id,'(%s)','g')]" % self.options.id_pattern
             self.id_to_process = self.document.xpath(path_to_compile, namespaces=new_nss)


### PR DESCRIPTION
This fixes the `AttributeError: module 'inkex.utils' has no attribute 'NSS'` error in Inkscape 1.1 + 1.2.x:
```
Traceback (most recent call last):
  File "inkporter.py", line 424, in <module>
    e.run ()
  File "/tmp/.mount_Inksca3tWo81/usr/share/inkscape/extensions/inkex/base.py", line 231, in run
    self.save_raw(self.effect())
  File "inkporter.py", line 389, in effect
    new_nss = inkex.utils.NSS
AttributeError: module 'inkex.utils' has no attribute 'NSS'
```

![image](https://user-images.githubusercontent.com/768942/201299960-b3601472-c49b-40c8-b2c9-ab41c2ada6a1.png)

I can see that someone else fixed it in the `windows-linux` directory - this fix is for the `linux` version of the code.